### PR TITLE
Fixes file loading test failing for empty directory

### DIFF
--- a/src/test/scala/pl/com/bms/fileSynchronizer/DirectoryToLoadTest.scala
+++ b/src/test/scala/pl/com/bms/fileSynchronizer/DirectoryToLoadTest.scala
@@ -1,6 +1,6 @@
 package pl.com.bms.fileSynchronizer
 
-import java.nio.file.NoSuchFileException
+import java.nio.file.{Paths, NoSuchFileException}
 
 import org.scalatest.{Matchers, WordSpec}
 import pl.com.bms.fileSynchronizer.config.DirectoryToLoad
@@ -10,8 +10,15 @@ class DirectoryToLoadTest extends WordSpec with Matchers {
   "DirectoryToLoad" when {
     "polled for list of files" should {
       "return an empty list for empty folder" in {
+        //given
+        val emptyDirectory = Paths.get("src/test/resources/emptyDirectory").toFile
+        emptyDirectory.mkdirs()
+        //when
         val directory = DirectoryToLoad("src/test/resources", "/emptyDirectory")
+        //then
         directory.filesToLoad() shouldBe empty
+        //clean up
+        emptyDirectory.delete()
       }
 
       "throw an exception for non-existent folder" in {
@@ -21,7 +28,9 @@ class DirectoryToLoadTest extends WordSpec with Matchers {
       }
 
       "return a list of files and folders" in {
+        //when
         val directory = DirectoryToLoad("src/test/resources", "/")
+        //then
         directory.filesToLoad() should contain allOf (
             "testDirectory",
             "testDirectory/testDirectory",

--- a/src/test/scala/pl/com/bms/fileSynchronizer/DirectoryToLoadTest.scala
+++ b/src/test/scala/pl/com/bms/fileSynchronizer/DirectoryToLoadTest.scala
@@ -1,36 +1,42 @@
 package pl.com.bms.fileSynchronizer
 
-import java.nio.file.{Paths, NoSuchFileException}
+import java.nio.file.NoSuchFileException
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 import pl.com.bms.fileSynchronizer.config.DirectoryToLoad
+import java.io.File
 
-class DirectoryToLoadTest extends WordSpec with Matchers {
+class DirectoryToLoadTest extends WordSpec with Matchers with BeforeAndAfter {
+
+  val TEST_RESOURCES_BASE = "src/test/resources"
+  val EMPTY_DIRECTORY_PATH = "/emptyDirectory"
 
   "DirectoryToLoad" when {
-    "polled for list of files" should {
-      "return an empty list for empty folder" in {
-        //given
-        val emptyDirectory = Paths.get("src/test/resources/emptyDirectory").toFile
-        emptyDirectory.mkdirs()
-        //when
-        val directory = DirectoryToLoad("src/test/resources", "/emptyDirectory")
-        //then
-        directory.filesToLoad() shouldBe empty
-        //clean up
-        emptyDirectory.delete()
+    "created on empty directory" should {
+      before {
+        new File(TEST_RESOURCES_BASE + EMPTY_DIRECTORY_PATH).mkdirs()
       }
 
+      "return an empty list for empty folder" in {
+        val directory = DirectoryToLoad(TEST_RESOURCES_BASE, EMPTY_DIRECTORY_PATH)
+        directory.filesToLoad() shouldBe empty
+      }
+      after {
+        new File(TEST_RESOURCES_BASE + EMPTY_DIRECTORY_PATH).delete()
+      }
+    }
+
+    "created on non-existent directory" should {
       "throw an exception for non-existent folder" in {
         intercept[NoSuchFileException] {
-          DirectoryToLoad("src/test/resources", "/do-not-exist").filesToLoad()
+          DirectoryToLoad(TEST_RESOURCES_BASE, "/do-not-exist").filesToLoad()
         }
       }
+    }
 
-      "return a list of files and folders" in {
-        //when
-        val directory = DirectoryToLoad("src/test/resources", "/")
-        //then
+    "created on non-empty directory" should {
+      "return a deep list of files and folders" in {
+        val directory = DirectoryToLoad(TEST_RESOURCES_BASE, "/")
         directory.filesToLoad() should contain allOf (
             "testDirectory",
             "testDirectory/testDirectory",


### PR DESCRIPTION
Because git doesn't allow you to commit empty directories,
I changed the test to create empty directory before the check
and to delete it after the check