### PR TITLE
Allows choosing Alfresco or ssh based on destination's root format

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -47,7 +47,7 @@ The application's configuration is by default placed in `config.json` file (file
   * `login` - User's login
   * `password` - User's password
 * `sourceRoot` - path of local directory inside which all the synchronized file will be located. This directory files and directories specified in next properties will be synchronized with remote host
-* `destinationRoot` - path of remote directory (ssh) or node ref (Alfresco) of folder which can be mapped to sourceRoot local directory
+* `destinationRoot` - path of remote directory (ssh) or node ref (Alfresco) of folder which can be mapped to sourceRoot local directory. Depending on this field, the application will upload files through ssh or http using Alfresco API.
 * `files` - list of all the file to keep synchronized
 * `directories` - list of all the directories to keep synchronized
 

--- a/src/main/scala/pl/com/bms/fileSynchronizer/Application.scala
+++ b/src/main/scala/pl/com/bms/fileSynchronizer/Application.scala
@@ -4,6 +4,7 @@ import java.nio.file.Paths
 
 import pl.com.bms.fileSynchronizer.config.Configuration
 import pl.com.bms.fileSynchronizer.fileUploader.TimePrinter
+import pl.com.bms.fileSynchronizer.fileUploader.alfresco.AlfrescoFileUploader
 import pl.com.bms.fileSynchronizer.fileUploader.ssh.SshFileUploader
 import pl.com.bms.fileSynchronizer.watch.FileWatcher
 
@@ -11,8 +12,10 @@ import pl.com.bms.fileSynchronizer.watch.FileWatcher
 class Application(config: Configuration) {
 
   val files = config.allFilesToLoad
-  val uploaderWithTimePrinter = new SshFileUploader(config) with TimePrinter
-
+  val uploaderWithTimePrinter = config.hasAlfrescoDestination match {
+    case true => new AlfrescoFileUploader(config) with TimePrinter
+    case false => new SshFileUploader(config) with TimePrinter
+  }
 
   def upload() = {
     files.foreach(fileToLoad => {

--- a/src/main/scala/pl/com/bms/fileSynchronizer/HelpPage.scala
+++ b/src/main/scala/pl/com/bms/fileSynchronizer/HelpPage.scala
@@ -27,6 +27,8 @@ object HelpPage {
       |
       |Above configuration will copy fileToSynchronize file and all files
       |from directoryToSynchronize directory into given destination.
+      |If you want to upload files to Alfresco, all you need to do is set
+      |destinationRoot, to a node ref instead of path.
       |
       |Additional options:
       | -h, --help               Display this message

--- a/src/main/scala/pl/com/bms/fileSynchronizer/config/Configuration.scala
+++ b/src/main/scala/pl/com/bms/fileSynchronizer/config/Configuration.scala
@@ -4,17 +4,26 @@ import spray.json.JsonParser
 
 case class Connection(login: String, password: String, url: String)
 
-case class Configuration(connection: Connection, sourceRoot: String, destinationRoot: String, files: List[String], directories: List[String]){
+case class Configuration(
+                          connection: Connection,
+                          sourceRoot: String,
+                          destinationRoot: String,
+                          files: List[String],
+                          directories: List[String]) extends Product{
+
+  val hasAlfrescoDestination = destinationRoot.startsWith("workspace://")
+
   def allFilesToLoad = {
     val filesFromDirectories = directories.flatMap(directory => DirectoryToLoad(sourceRoot, directory).filesToLoad())
     files ::: directories ::: filesFromDirectories
   }
+  
 }
 
 object Configuration{
-  import pl.com.bms.fileSynchronizer.config.MyJsonProtocol._
 
   def load(configFileName: String = "config.json"): Configuration = {
+    import pl.com.bms.fileSynchronizer.config.MyJsonProtocol._
     val configFile = loadConfigFile(configFileName)
     val config = JsonParser(configFile).convertTo[Configuration]
     config

--- a/src/main/scala/pl/com/bms/fileSynchronizer/config/MyJsonProtocol.scala
+++ b/src/main/scala/pl/com/bms/fileSynchronizer/config/MyJsonProtocol.scala
@@ -4,6 +4,5 @@ import spray.json.DefaultJsonProtocol
 
 object MyJsonProtocol extends DefaultJsonProtocol {
   implicit val connectionFormat3 = jsonFormat3(Connection)
-//  implicit val directoryToLoadFormat = jsonFormat1(DirectoryToLoad.apply)
   implicit val configurationFormat = jsonFormat5(Configuration.apply)
 }

--- a/src/test/scala/pl/com/bms/fileSynchronizer/config/ConfigurationTest.scala
+++ b/src/test/scala/pl/com/bms/fileSynchronizer/config/ConfigurationTest.scala
@@ -1,0 +1,29 @@
+package pl.com.bms.fileSynchronizer.config
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class ConfigurationTest extends FlatSpec with Matchers {
+
+  "Configuration" should "detect Alfresco destination" in {
+    val configuration = Configuration(
+      Connection("","",""),
+      "",
+      "workspace://SpacesStore/17855f47-ef83-4eeb-b9f0-a41f07ab6cac",
+      List(),
+      List()
+    )
+    configuration.hasAlfrescoDestination shouldBe true
+  }
+
+  it should "detect ssh destination" in {
+    val configuration = Configuration(
+      Connection("","",""),
+      "",
+      "/home/user/folder",
+      List(),
+      List()
+    )
+    configuration.hasAlfrescoDestination shouldBe false
+  }
+
+}


### PR DESCRIPTION
After adding support for ssh upload the only way to switch between
ssh and Alfresco mode was to change it inside code and recompile app.
Now the mode will be determined based on destinationRoot configuration
field format.

Fixes #6