### PR TITLE
Set application version based on `git describe` output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,10 @@ name := "FileSynchronizer"
 
 organization := "pl.com.bms"
 
-version := "0.3"
+enablePlugins(GitVersioning)
+git.useGitDescribe := true
+
+assemblyJarName in assembly := s"${name.value}-${version.value}.jar"
 
 scalaVersion := "2.11.6"
 

--- a/config.json
+++ b/config.json
@@ -4,8 +4,8 @@
     "password": "password",
     "url": "host"
   },
-  "sourceRoot": "/home/user/files",
-  "destinationRoot": "/remoteHost/files",
+  "sourceRoot": "/home/user/files/",
+  "destinationRoot": "/remoteHost/files/",
   "files": [
     "fileToSynchronize"
   ],

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,4 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.0")

--- a/src/main/scala/pl/com/bms/fileSynchronizer/HelpPage.scala
+++ b/src/main/scala/pl/com/bms/fileSynchronizer/HelpPage.scala
@@ -15,8 +15,8 @@ object HelpPage {
       |    "password": "password",
       |    "url": "host"
       |  },
-      |  "sourceRoot": "/home/user/files",
-      |  "destinationRoot": "/remoteHost/files",
+      |  "sourceRoot": "/home/user/files/",
+      |  "destinationRoot": "/remoteHost/files/",
       |  "files": [
       |    "fileToSynchronize"
       |  ],


### PR DESCRIPTION
![](http://image.slidesharecdn.com/a-3-3d89fc2309e6e7c7333c06fa0b515c8876426c7f-150225223614-conversion-gate01/95/version-all-the-things-1-638.jpg?cb=1424931310)

I've used sbt-git plugin to set `git describe` output as a project version.
Additionally I've removed `assembly` text from the jar's name, and added
tailing slash to example configuration.

Fixes #16